### PR TITLE
Fix Text anchor and test align

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "0.0.2-rc11",
+  "version": "0.0.2-rc12",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/src/plugins/elements/TextRendererPlugin.js
+++ b/src/plugins/elements/TextRendererPlugin.js
@@ -102,13 +102,13 @@ export class TextRendererPlugin {
       if (element.y !== undefined) {
         newText.y = element.y;
       }
-      if (element.xa !== undefined) {
-        newText.anchor.x = element.xa;
+      if (element.anchorX !== undefined) {
+        newText.anchor.x = element.anchorX;
       }
-      if (element.ya !== undefined) {
-        newText.anchor.y = element.ya;
+      if (element.anchorY !== undefined) {
+        newText.anchor.y = element.anchorY;
       }
-      if (element.xa !== undefined || element.ya !== undefined) {
+      if (element.anchorX !== undefined || element.anchorY !== undefined) {
         const bounds = newText.getLocalBounds();
         newText.hitArea = new Rectangle(
           -bounds.width * newText.anchor.x,

--- a/vt/specs/textbasic/align.yaml
+++ b/vt/specs/textbasic/align.yaml
@@ -1,0 +1,191 @@
+---
+title: Align
+---
+states:
+  - elements:
+    - id: 'anchor'
+      type: "rect"
+      x: 660
+      y: 240
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'tl'
+      type: "text"
+      text: "This text is aligned to the top left corner"
+      x: 660
+      y: 240
+      anchorX: 0
+      anchorY: 0
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+    - id: 'anchor'
+      type: "rect"
+      x: 960
+      y: 240
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'tc'
+      type: "text"
+      text: "This text is aligned to the top center"
+      x: 960
+      y: 240
+      anchorX: 0.5
+      anchorY: 0
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+        align: "center"
+    - id: 'anchor'
+      type: "rect"
+      x: 1260
+      y: 240
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'tr'
+      type: "text"
+      text: "This text is aligned to the top right corner"
+      x: 1260
+      y: 240
+      anchorX: 1
+      anchorY: 0
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+        align: "right"
+    - id: 'anchor'
+      type: "rect"
+      x: 660
+      y: 540
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'cl'
+      type: "text"
+      text: "This text is aligned to the center left"
+      x: 660
+      y: 540
+      anchorX: 0
+      anchorY: 0.5
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+    - id: 'anchor'
+      type: "rect"
+      x: 960
+      y: 540
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'cc'
+      type: "text"
+      text: "This text is aligned to the center"
+      x: 960
+      y: 540
+      anchorX: 0.5
+      anchorY: 0.5
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+        align: "center"
+    - id: 'anchor'
+      type: "rect"
+      x: 1260
+      y: 540
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'cr'
+      type: "text"
+      text: "This text is aligned to the center right"
+      x: 1260
+      y: 540
+      anchorX: 1
+      anchorY: 0.5
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+        align: "right"
+    - id: 'anchor'
+      type: "rect"
+      x: 660
+      y: 840
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'bl'
+      type: "text"
+      text: "This text is aligned to the bottom left corner"
+      x: 660
+      y: 840
+      anchorX: 0
+      anchorY: 1
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+    - id: 'anchor'
+      type: "rect"
+      x: 960
+      y: 840
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'bc'
+      type: "text"
+      text: "This text is aligned to the bottom center"
+      x: 960
+      y: 840
+      anchorX: 0.5
+      anchorY: 1
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+        align: "center"
+    - id: 'anchor'
+      type: "rect"
+      x: 1260
+      y: 840
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'br'
+      type: "text"
+      text: "This text is aligned to the bottom right corner"
+      x: 1260
+      y: 840
+      anchorX: 1
+      anchorY: 1
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 150
+        align: "right"

--- a/vt/specs/textbasic/anchor.yaml
+++ b/vt/specs/textbasic/anchor.yaml
@@ -3,102 +3,111 @@ title: Anchor
 ---
 states:
   - elements:
-      - id: 'tl'
-        type: "text"
-        text: "Hello World"
-        x: 760
-        y: 340
-        anchorX: 0
-        anchorY: 0
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'tc'
-        type: "text"
-        text: "Hello World"
-        x: 960
-        y: 340
-        anchorX: 0.5
-        anchorY: 0
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'tr'
-        type: "text"
-        text: "Hello World"
-        x: 1160
-        y: 340
-        anchorX: 1
-        anchorY: 0
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'cl'
-        type: "text"
-        text: "Hello World"
-        x: 760
-        y: 540
-        anchorX: 0
-        anchorY: 0.5
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'cc'
-        type: "text"
-        text: "Hello World"
-        x: 960
-        y: 540
-        anchorX: 0.5
-        anchorY: 0.5
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'cr'
-        type: "text"
-        text: "Hello World"
-        x: 1160
-        y: 540
-        anchorX: 1
-        anchorY: 0.5
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'bl'
-        type: "text"
-        text: "Hello World"
-        x: 760
-        y: 740
-        anchorX: 0
-        anchorY: 1
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'bc'
-        type: "text"
-        text: "Hello World"
-        x: 960
-        y: 740
-        anchorX: 0.5
-        anchorY: 1
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
-      - id: 'br'
-        type: "text"
-        text: "Hello World"
-        x: 1160
-        y: 740
-        anchorX: 1
-        anchorY: 1
-        style: 
-          fontSize: 24
-          fill: "white"
-          wordWrapWidth: 300
+    - id: 'anchor'
+      type: "rect"
+      x: 960
+      y: 540
+      width: 25
+      height: 25
+      anchorX: 0.5
+      anchorY: 0.5
+      fill: red
+    - id: 'tl'
+      type: "text"
+      text: "Hello World"
+      x: 760
+      y: 340
+      anchorX: 0
+      anchorY: 0
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'tc'
+      type: "text"
+      text: "Hello World"
+      x: 960
+      y: 340
+      anchorX: 0.5
+      anchorY: 0
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'tr'
+      type: "text"
+      text: "Hello World"
+      x: 1160
+      y: 340
+      anchorX: 1
+      anchorY: 0
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'cl'
+      type: "text"
+      text: "Hello World"
+      x: 760
+      y: 540
+      anchorX: 0
+      anchorY: 0.5
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'cc'
+      type: "text"
+      text: "Hello World"
+      x: 960
+      y: 540
+      anchorX: 0.5
+      anchorY: 0.5
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'cr'
+      type: "text"
+      text: "Hello World"
+      x: 1160
+      y: 540
+      anchorX: 1
+      anchorY: 0.5
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'bl'
+      type: "text"
+      text: "Hello World"
+      x: 760
+      y: 740
+      anchorX: 0
+      anchorY: 1
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'bc'
+      type: "text"
+      text: "Hello World"
+      x: 960
+      y: 740
+      anchorX: 0.5
+      anchorY: 1
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300
+    - id: 'br'
+      type: "text"
+      text: "Hello World"
+      x: 1160
+      y: 740
+      anchorX: 1
+      anchorY: 1
+      style: 
+        fontSize: 24
+        fill: "white"
+        wordWrapWidth: 300

--- a/vt/specs/textbasic/anchor.yaml
+++ b/vt/specs/textbasic/anchor.yaml
@@ -1,0 +1,104 @@
+---
+title: Anchor
+---
+states:
+  - elements:
+      - id: 'tl'
+        type: "text"
+        text: "Hello World"
+        x: 760
+        y: 340
+        anchorX: 0
+        anchorY: 0
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'tc'
+        type: "text"
+        text: "Hello World"
+        x: 960
+        y: 340
+        anchorX: 0.5
+        anchorY: 0
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'tr'
+        type: "text"
+        text: "Hello World"
+        x: 1160
+        y: 340
+        anchorX: 1
+        anchorY: 0
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'cl'
+        type: "text"
+        text: "Hello World"
+        x: 760
+        y: 540
+        anchorX: 0
+        anchorY: 0.5
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'cc'
+        type: "text"
+        text: "Hello World"
+        x: 960
+        y: 540
+        anchorX: 0.5
+        anchorY: 0.5
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'cr'
+        type: "text"
+        text: "Hello World"
+        x: 1160
+        y: 540
+        anchorX: 1
+        anchorY: 0.5
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'bl'
+        type: "text"
+        text: "Hello World"
+        x: 760
+        y: 740
+        anchorX: 0
+        anchorY: 1
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'bc'
+        type: "text"
+        text: "Hello World"
+        x: 960
+        y: 740
+        anchorX: 0.5
+        anchorY: 1
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300
+      - id: 'br'
+        type: "text"
+        text: "Hello World"
+        x: 1160
+        y: 740
+        anchorX: 1
+        anchorY: 1
+        style: 
+          fontSize: 24
+          fill: "white"
+          wordWrapWidth: 300


### PR DESCRIPTION
<img width="515" height="378" alt="image" src="https://github.com/user-attachments/assets/4056c3c6-2f91-4f10-af7d-61079e047e2d" />

- Change `xa`, `ya` to `anchorX` and `anchorY`
- the align attr can use. if we want to fully make it reach unity's function, may need add an extra container outside the current text to realize. but i wonder if it is necessary